### PR TITLE
10 plugin ctrl explore trial

### DIFF
--- a/build_control_timeline.js
+++ b/build_control_timeline.js
@@ -14,7 +14,7 @@ explore_sequence.forEach(trial => {
         timeline: [{
           type: jsPsychExploreShipFeedback,
           on_finish: function (data) {
-            console.log(data);
+            // console.log(data);
           }
         }],
         conditional_function: function () {

--- a/ctrl-plugins/plugin-ctrl-explore-trial.js
+++ b/ctrl-plugins/plugin-ctrl-explore-trial.js
@@ -309,7 +309,7 @@ var jsPsychExploreShip = (function (jspsych) {
         responseTime: Array.from({ length: trial_presses }, () => Math.floor(this.jsPsych.randomization.sampleExGaussian(125, 15, 0.5, true))),
         trial_presses: trial_presses
       };
-      
+
       const data = this.jsPsych.pluginAPI.mergeSimulationData(default_data, simulation_options);
       this.jsPsych.pluginAPI.ensureSimulationDataConsistency(trial, data);
       return data;
@@ -324,8 +324,10 @@ var jsPsychExploreShip = (function (jspsych) {
       const choiceToKey = {"left": "ArrowLeft", "right": "ArrowRight"};
       const data = this.create_simulation_data(trial, simulation_options);
       const display_element = this.jsPsych.getDisplayElement();
+
       this.trial(display_element, trial);
       load_callback();
+
       if (data.rt!== null) {
         let t = data.rt;
         this.jsPsych.pluginAPI.pressKey(choiceToKey[data.response], t);
@@ -492,6 +494,64 @@ var jsPsychExploreShipFeedback = (function (jspsych) {
         display_element.innerHTML = '';
         this.jsPsych.finishTrial(trial_data);
       }, trial.feedback_duration);
+    }
+
+    // Simulation function
+    simulate(trial, simulation_mode, simulation_options, load_callback) {
+      if (simulation_mode == "data-only") {
+        load_callback();
+        this.simulate_data_only(trial, simulation_options);
+      }
+      if (simulation_mode == "visual") {
+        this.simulate_visual(trial, simulation_options, load_callback);
+      }
+    }
+
+    create_simulation_data(trial, simulation_options) {
+      // Get data from previous trial
+      const lastTrial = this.jsPsych.data.getLastTrialData().values()[0];
+      const choice = lastTrial.response; // 'left' or 'right'
+      const chosenColor = this.jsPsych.evaluateTimelineVariable(choice);
+      const nearIsland = this.jsPsych.evaluateTimelineVariable('near');
+      const currentStrength = this.jsPsych.evaluateTimelineVariable('current');
+      const effortLevel = lastTrial.trial_presses;
+
+      // Determine destination island based on control rule
+      const currentRule = this.chooseControlRule(
+        effortLevel, 
+        currentStrength
+      );
+
+      const destinationIsland = currentRule === 'base' 
+        ? this.baseRule[nearIsland]
+        : this.controlRule[chosenColor];
+
+      const default_data = {
+        trialphase: "explore_feedback",
+        destination_island: destinationIsland,
+        control_rule_used: currentRule,
+        effort_level: effortLevel,
+        current_strength: currentStrength,
+        ship_color: chosenColor,
+        near_island: nearIsland,
+        probability_control: this.sigmoid((effortLevel - this.effort_threshold[currentStrength - 1]) * this.scale)
+      };
+      
+      const data = this.jsPsych.pluginAPI.mergeSimulationData(default_data, simulation_options);
+      this.jsPsych.pluginAPI.ensureSimulationDataConsistency(trial, data);
+      return data;
+    }
+
+    simulate_data_only(trial, simulation_options) {
+      const data = this.create_simulation_data(trial, simulation_options);
+      this.jsPsych.finishTrial(data);
+    }
+
+    simulate_visual(trial, simulation_options, load_callback) {
+      const data = this.create_simulation_data(trial, simulation_options);
+      const display_element = this.jsPsych.getDisplayElement();
+      this.trial(display_element, trial);
+      load_callback();
     }
   }
 

--- a/ctrl-plugins/plugin-ctrl-explore-trial.js
+++ b/ctrl-plugins/plugin-ctrl-explore-trial.js
@@ -125,6 +125,7 @@ var jsPsychExploreShip = (function (jspsych) {
       let responseTime = [];
       let choice = null;
       let choice_rt = 0;
+      let repeated_listener = null;
 
       // Generate HTML for the trial
       const generateHTML = () => {
@@ -234,7 +235,7 @@ var jsPsychExploreShip = (function (jspsych) {
 
       // Setup repeated keypress listener
       const setupRepeatedKeypress = (key) => {
-        this.jsPsych.pluginAPI.getKeyboardResponse({
+        repeated_listener = this.jsPsych.pluginAPI.getKeyboardResponse({
           callback_function: handleRepeatedKeypress,
           valid_responses: [key],
           rt_method: 'performance',
@@ -263,7 +264,11 @@ var jsPsychExploreShip = (function (jspsych) {
 
       // Function to end trial
       const endTrial = () => {
-        this.jsPsych.pluginAPI.cancelAllKeyboardResponses();
+        if (typeof repeated_listener !== 'undefined') {
+          this.jsPsych.pluginAPI.cancelKeyboardResponse(repeated_listener);
+        } else {
+          this.jsPsych.pluginAPI.cancelAllKeyboardResponses();
+        }
         display_element.innerHTML = '';
 
         // Save data


### PR DESCRIPTION
This pull request includes several enhancements and fixes to the `ctrl-plugins/plugin-ctrl-explore-trial.js` file, with a minor change to the `build_control_timeline.js` file. The most significant changes involve adding simulation functions, improving keypress handling, and ensuring proper cleanup of keyboard listeners.

Enhancements to simulation capabilities:

* Added simulation functions `simulate`, `create_simulation_data`, `simulate_data_only`, and `simulate_visual` to the `ExploreShipPlugin` class. These functions facilitate the generation of simulated trial data and visual simulations.
* Implemented similar simulation functions in the `ExploreShipFeedbackPlugin` class to simulate feedback trials.

Improvements to keypress handling:

* Introduced a new parameter `choices` to specify valid key responses for the trial, replacing hardcoded key values.
* Updated the initial keyboard listener to use the `choices` parameter for valid responses.

Ensuring proper cleanup:

* Added logic to cancel the specific repeated keypress listener if it exists, otherwise cancel all keyboard responses to ensure proper cleanup at the end of the trial.

Minor change:

* Commented out a console log statement in the `build_control_timeline.js` file to clean up the output.