### PR TITLE
11 plugin ctrl predict trial

### DIFF
--- a/ctrl-plugins/plugin-ctrl-predict-trial.js
+++ b/ctrl-plugins/plugin-ctrl-predict-trial.js
@@ -123,7 +123,7 @@ var jsPsychPredictHomeBase = (function (jspsych) {
       // Set up keyboard listener
       const keyboardListener = this.jsPsych.pluginAPI.getKeyboardResponse({
         callback_function: handleKeypress,
-        valid_responses: Object.keys(this.keyList),
+        valid_responses: trial.choices,
         rt_method: 'performance',
         persist: false,
         allow_held_key: false

--- a/ctrl-plugins/plugin-ctrl-predict-trial.js
+++ b/ctrl-plugins/plugin-ctrl-predict-trial.js
@@ -210,18 +210,6 @@ var jsPsychPredictDest = (function (jspsych) {
       },
       rt: {
         type: jspsych.ParameterType.INT
-      },
-      ship: {
-        type: jspsych.ParameterType.STRING
-      },
-      near: {
-        type: jspsych.ParameterType.STRING
-      },
-      current: {
-        type: jspsych.ParameterType.INT
-      },
-      fuel_lvl: {
-        type: jspsych.ParameterType.INT
       }
     }
   };
@@ -338,11 +326,7 @@ var jsPsychPredictDest = (function (jspsych) {
         const trial_data = {
           trialphase: "predict_dest",
           response: choice,
-          rt: choice_rt,
-          ship: trial.ship,
-          near: trial.near,
-          current: trial.current,
-          fuel_lvl: trial.fuel_lvl
+          rt: choice_rt
         };
 
         // Clear display

--- a/ctrl-plugins/plugin-ctrl-predict-trial.js
+++ b/ctrl-plugins/plugin-ctrl-predict-trial.js
@@ -20,6 +20,11 @@ var jsPsychPredictHomeBase = (function (jspsych) {
         default: 500,
         description: "Delay after choice before ending trial (ms)"
       },
+      choices : {
+        type: jspsych.ParameterType.KEYS,
+        default: ["d", "f", "j", "k"],
+        description: "Keys for island selection"
+      },
       post_trial_gap: {
         type: jspsych.ParameterType.INT,
         default: 300,

--- a/ctrl-plugins/plugin-ctrl-predict-trial.js
+++ b/ctrl-plugins/plugin-ctrl-predict-trial.js
@@ -138,7 +138,7 @@ var jsPsychPredictHomeBase = (function (jspsych) {
 
       const endTrial = () => {
         // Kill keyboard listeners
-        this.jsPsych.pluginAPI.cancelAllKeyboardResponses();
+        this.jsPsych.pluginAPI.cancelKeyboardResponse(keyboardListener);
 
         // Save data
         const trial_data = {

--- a/ctrl-plugins/plugin-ctrl-predict-trial.js
+++ b/ctrl-plugins/plugin-ctrl-predict-trial.js
@@ -67,6 +67,14 @@ var jsPsychPredictHomeBase = (function (jspsych) {
         'j': 2,
         'k': 3
       };
+
+      // Home base answers
+      this.controlRule = {
+        green: "coconut",
+        blue: "grape",
+        red: "orange",
+        yellow: "banana"
+      };
     }
 
     trial(display_element, trial) {
@@ -155,6 +163,48 @@ var jsPsychPredictHomeBase = (function (jspsych) {
         // End trial
         this.jsPsych.finishTrial(trial_data);
       };
+    }
+
+    // Simulation function
+    simulate(trial, simulation_mode, simulation_options, load_callback) {
+      if (simulation_mode == "data-only") {
+        load_callback();
+        this.simulate_data_only(trial, simulation_options);
+      }
+      if (simulation_mode == "visual") {
+        this.simulate_visual(trial, simulation_options, load_callback);
+      }
+    }
+
+    create_simulation_data(trial, simulation_options) {
+      let choice = this.keyList[this.jsPsych.pluginAPI.getValidKey(trial.choices)];
+      const default_data = {
+        trialphase: "predict_homebase",
+        response: choice,
+        rt: Math.floor(this.jsPsych.randomization.sampleExGaussian(500, 50, 1 / 150, true)),
+        correct: this.controlRule[trial.ship] === Object.keys(this.islandKeyList)[choice],
+        ship: trial.ship
+      };
+
+      const data = this.jsPsych.pluginAPI.mergeSimulationData(default_data, simulation_options);
+      this.jsPsych.pluginAPI.ensureSimulationDataConsistency(trial, data);
+      return data;
+    }
+
+    simulate_data_only(trial, simulation_options) {
+      const data = this.create_simulation_data(trial, simulation_options);
+      this.jsPsych.finishTrial(data);
+    }
+
+    simulate_visual(trial, simulation_options, load_callback) {
+      const data = this.create_simulation_data(trial, simulation_options);
+      const display_element = this.jsPsych.getDisplayElement();
+      this.trial(display_element, trial);
+      load_callback();
+
+      if (data.rt!== null) {
+        this.jsPsych.pluginAPI.pressKey(Object.keys(this.keyList)[data.response], data.rt);
+      }
     }
   }
 

--- a/ctrl-plugins/plugin-ctrl-predict-trial.js
+++ b/ctrl-plugins/plugin-ctrl-predict-trial.js
@@ -332,7 +332,7 @@ var jsPsychPredictDest = (function (jspsych) {
 
       const endTrial = () => {
         // Kill keyboard listeners
-        this.jsPsych.pluginAPI.cancelAllKeyboardResponses();
+        this.jsPsych.pluginAPI.cancelKeyboardResponse(keyboardListener);
 
         // Save data
         const trial_data = {

--- a/ctrl-plugins/plugin-ctrl-predict-trial.js
+++ b/ctrl-plugins/plugin-ctrl-predict-trial.js
@@ -145,6 +145,7 @@ var jsPsychPredictHomeBase = (function (jspsych) {
           trialphase: "predict_homebase",
           response: choice,
           rt: choice_rt,
+          correct: this.controlRule[trial.ship] === Object.keys(this.islandKeyList)[choice],
           ship: trial.ship
         };
 

--- a/ctrl-plugins/plugin-ctrl-predict-trial.js
+++ b/ctrl-plugins/plugin-ctrl-predict-trial.js
@@ -95,7 +95,7 @@ var jsPsychPredictHomeBase = (function (jspsych) {
             </div>
           </section>
         </div>
-        <p>Which island is the home base of this ship?</p>
+        <p style="position: relative; top: -5vh;">Which island is the home base of this ship?</p>
         <div class="island-choices">
           ${Object.entries(this.islandKeyList).map(([island, key]) => `
             <div class="destination-button" data-choice="${this.keyList[key]}">
@@ -325,7 +325,7 @@ var jsPsychPredictDest = (function (jspsych) {
             ${this.createOceanCurrents(trial.current)}
           </section>
         </div>
-        <p>Based on the current strength and fuel level, where will this ship most likely dock?</p>
+        <p style="position: relative; top: -5vh;">Based on the current strength and fuel level, where will this ship most likely dock?</p>
         <div class="island-choices">
           ${Object.entries(this.islandKeyList).map(([island, key]) => `
             <div class="destination-button" data-choice="${this.keyList[key]}">

--- a/instruction_style.css
+++ b/instruction_style.css
@@ -21,7 +21,7 @@
 /* Background elements positioning */
 .instruction-stage .background {
   position: absolute;
-  top: -8%;
+  top: -5vh;
   left: 0;
   width: 100%;
   height: 100%;
@@ -32,7 +32,7 @@
 /* Scene layout and positioning */
 .instruction-stage .scene {
   position: absolute;
-  top: -8%;
+  top: -5vh;
   left: 0;
   width: 100%;
   height: 70%; /* Increased height for more space */

--- a/style.css
+++ b/style.css
@@ -251,3 +251,9 @@
 .ship-display {
   transition: transform 0.3s ease;
 }
+
+/* Prediction choice styles */
+.island-choices {
+  position: relative;
+  top: -5vh;
+}


### PR DESCRIPTION
This pull request includes several changes to the `ctrl-plugins/plugin-ctrl-predict-trial.js` file to enhance functionality and improve user experience. Additionally, there are some style adjustments in the `instruction_style.css` and `style.css` files. The most important changes include the addition of new parameters, simulation functions, and style updates.

Enhancements to `ctrl-plugins/plugin-ctrl-predict-trial.js`:

* Added `choices` parameter to define keys for island selection.
* Introduced `controlRule` for home base answers.
* Implemented simulation functions `simulate`, `create_simulation_data`, `simulate_data_only`, and `simulate_visual`.
* Updated the keyboard listener to use the new `choices` parameter.
* Adjusted trial data to include the correctness of the response.

Style adjustments:

* Updated positioning of elements in `instruction_style.css` and `style.css` to use `vh` units for better responsiveness. [[1]](diffhunk://#diff-163c1a4aeca1cd08c6bd30739854fa750d9a45a3a9a76e5716fee28717b02981L24-R24) [[2]](diffhunk://#diff-163c1a4aeca1cd08c6bd30739854fa750d9a45a3a9a76e5716fee28717b02981L35-R35) [[3]](diffhunk://#diff-b78be019f1dc6d57753ea900c3805b114cd53ab7c0db836cc081836df1b99b7aR254-R259)